### PR TITLE
Clarify markview lazy load comment

### DIFF
--- a/lua/plugins/plugin_list.lua
+++ b/lua/plugins/plugin_list.lua
@@ -173,7 +173,7 @@ return {
   {
 	"OXY2DEV/markview.nvim",
 	opts = {},
-	lazy = true, -- false Recommended
+        lazy = true, -- set to false to load on startup (recommended)
 	ft = "markdown", -- If you decide to lazy-load anyway
 
 	dependencies = {


### PR DESCRIPTION
## Summary
- clarify markview.nvim plugin comment about recommended lazy-loading

## Testing
- `luac -p lua/plugins/plugin_list.lua`


------
https://chatgpt.com/codex/tasks/task_e_689450f5805c83228d4dccdb95e7f628