### PR TITLE
fix: correct oil mapping comment

### DIFF
--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -1,7 +1,7 @@
 -- luacheck: globals vim
 local opts = { noremap = true, silent = true }
 
--- Map <leader>e to open oil.nvim (your file explorer)
+-- Map - to open oil.nvim (file explorer)
 vim.keymap.set("n", "-", "<CMD>Oil<CR>", opts)
 
 -- Insert mode cursor movement with Ctrl+hjkl


### PR DESCRIPTION
## Summary
- clarify keymap comment for Oil file explorer

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_689450f6d6508322a4aae04ed5da0cb6