### PR TITLE
Add test for plugin list plugin names

### DIFF
--- a/lua/plugins/plugin_list.lua
+++ b/lua/plugins/plugin_list.lua
@@ -107,30 +107,28 @@ return {
   },
 
   {
-    {
-      "saecki/crates.nvim",
-      tag = "stable",
-      event = { "BufRead Cargo.toml" },
-      config = function()
-        local crates = require("crates")
-        crates.setup({
-          lsp = {
+    "saecki/crates.nvim",
+    tag = "stable",
+    event = { "BufRead Cargo.toml" },
+    config = function()
+      local crates = require("crates")
+      crates.setup({
+        lsp = {
+          enabled = true,
+          actions = true,
+          completion = true,
+          hover = true,
+        },
+        completion = {
+          cmp = {
             enabled = true,
-            actions = true,
-            completion = true,
-            hover = true,
           },
-          completion = {
-            cmp = {
-              enabled = true,
-            },
-          },
-        })
+        },
+      })
 
-        -- Keymaps
-        vim.keymap.set("n", "<leader>cf", crates.show_features_popup, { desc = "Show Crate Features" })
-      end,
-    },
+      -- Keymaps
+      vim.keymap.set("n", "<leader>cf", crates.show_features_popup, { desc = "Show Crate Features" })
+    end,
   },
 {
   'mrcjkb/rustaceanvim',

--- a/tests/plugin_list_spec.lua
+++ b/tests/plugin_list_spec.lua
@@ -1,0 +1,15 @@
+package.path = package.path .. ';./lua/?.lua;./lua/?/init.lua'
+
+local plugin_list = require('plugins.plugin_list')
+
+describe('plugin list', function()
+  it('has string plugin names', function()
+    for i, plugin in ipairs(plugin_list) do
+      assert(
+        type(plugin[1]) == 'string',
+        string.format('Plugin entry %d should have a string as the first element', i)
+      )
+    end
+  end)
+end)
+


### PR DESCRIPTION
## Summary
- fix crates.nvim plugin entry structure
- add busted test to ensure each plugin spec's first element is a string

## Testing
- `busted tests/plugin_list_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_6894510680a08322998ba0705d0e71a0